### PR TITLE
ci: Fix release action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -125,6 +125,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-library, update-changelog]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: "Release to the public PyPI repository"
         uses: ansys/actions/release-pypi-public@v8
@@ -136,6 +139,7 @@ jobs:
         uses: ansys/actions/release-github@v8
         with:
           library-name: ${{ env.LIBRARY_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-deploy-dev:
     name: "Deploy development documentation"

--- a/doc/changelog.d/19.maintenance.md
+++ b/doc/changelog.d/19.maintenance.md
@@ -1,0 +1,1 @@
+ci: Fix release action


### PR DESCRIPTION
Add permissions and missing `token` input for `ansys/actions/release-github@v8`