### PR TITLE
chore: Enable Python 3.12 and greater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,7 +118,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/doc/changelog.d/21.documentation.md
+++ b/doc/changelog.d/21.documentation.md
@@ -1,0 +1,1 @@
+chore: Enable Python 3.12 and greater

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -85,10 +85,12 @@ to guarantee the project's integrity.
 
 The following ``tox`` commands are provided:
 
-- ``tox -e style``: Checks for coding style quality.
-- ``tox -e py``: Checks for unit tests.
-- ``tox -e py-coverage``: Checks for unit testing and code coverage.
-- ``tox -e doc``: Checks for the documentation-building process.
+* ``tox -e code-style``: Checks for coding style quality.
+* ``tox -e py-tests``: Checks for unit testing without code coverage.
+* ``tox -e py-tests-coverage``: Checks for unit testing with code coverage.
+* ``tox -e doc``: Checks for the documentation-building process.
+   * ``tox -e doc-html``: Builds the HTML documentation.
+   * ``tox -e doc-links``: Checks for broken links in the documentation.
 
 Use raw testing
 ^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers=[
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ version="1.1.dev0"
 description ="Python toolbox for Ansys SCADE LifeCycle ALM Gateway."
 readme="README.rst"
 
-# only 3.7. and 3.10
-requires-python = ">=3.7,!=3.8.*,!=3.9.*,<3.11"
+# only 3.7, 3.10, or >= 3.12
+requires-python = ">=3.7,!=3.8.*,!=3.9.*,!=3.11.*"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
@@ -20,7 +20,7 @@ maintainers = [
 dependencies=[
     "importlib-metadata >= 1.0; python_version < '3.8'",
     "importlib-metadata >= 4.0; python_version >= '3.8'",
-    "ansys-scade-apitools",
+    "ansys-scade-apitools >= 0.5",
     "lxml",
 ]
 classifiers=[
@@ -39,9 +39,10 @@ build = [
     "twine==6.1.0"
 ]
 tests = [
-    # 8.0.2 at most: https://github.com/microsoft/PTVS/issues/7853
-    "pytest==8.3.4",
-    "pytest-cov==6.0.0",
+    "pytest >= 8.3.4; python_version >= '3.8'",
+    "pytest <= 7.4.4; python_version < '3.8'",
+    "pytest-cov >= 6.0.0; python_version >= '3.8'",
+    "pytest-cov <= 4.1.0; python_version < '3.8'",
     # required for SCADE Display API
     "pyparsing",
 ]

--- a/tests/test_llrs.py
+++ b/tests/test_llrs.py
@@ -170,7 +170,7 @@ def _run_export(
     dst = tmp / ref.name
     cmd = [
         sys.executable,
-        _pyalmgw_dir / 'llrs.py',
+        str(_pyalmgw_dir / 'llrs.py'),
         str(path),
         str(dst),
         str(schema),
@@ -323,11 +323,11 @@ def test_llr_robustness(local_tmpdir, index, project, args):
     dst = local_tmpdir / ('robustness_%d.json' % index)
     cmd = [
         sys.executable,
-        _pyalmgw_dir / 'llrs.py',
+        str(_pyalmgw_dir / 'llrs.py'),
         str(path),
         str(dst),
     ]
-    cmd.extend(args)
+    cmd.extend([str(_) for _ in args])
     status = subprocess.run(cmd, capture_output=True)
     print(status.stderr.decode('utf-8').strip('\n'))
     print(status.stdout.decode('utf-8').strip('\n'))

--- a/tox.ini
+++ b/tox.ini
@@ -1,34 +1,42 @@
 [tox]
 description = Default tox environments list
-envlist = code-style, py{310}-{default,coverage}, doc-{links,html}
+# coverage is optional but includes tests: by default run only coverage
+# 312 available with Ansys SCADE 2026 R1, not released yet
+# env_list = code-style, py{37,310,312}-tests{-coverage,}, doc-{links,html}
+env_list = code-style, py{37,310}-tests-coverage, doc-{links,html}
 skip_missing_interpreters = true
-isolated_build = true
 isolated_build_env = build
 
-[gh-actions]
-description = The tox environment to be executed in gh-actions for a given python version
-python =
-    3.10: style, py310-coverage, doc
-
-[testenv]
-description = Checks for project unit tests and coverage (if desired)
+[testenv:py{37, 310, 312}-tests{-coverage,}]
+description =
+    Checks for project unit tests
+    coverage: and coverage
+    py37: with python version 3.7
+    py310: with python version 3.10
+    py312: with python version 3.12
 extras = tests
 setenv =
+    TEMP = {env_tmp_dir}
+    TMP = {env_tmp_dir}
     PYTHONUNBUFFERED = yes
-    coverage: PYTEST_EXTRA_ARGS = --cov=ansys.scade --cov-report=term --cov-report=xml:.cov/xml --cov-report=html:.cov/html --cov-branch
+    coverage: PYTEST_EXTRA_ARGS = --cov=ansys.scade --cov-report=term --cov-report=xml:.cov/.{env_name}/xml --cov-report=html:.cov/.{env_name}/html --cov-branch
+passenv =
+    ANSYSLMD_LICENSE_FILE
 commands =
-    pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+    python -m pytest -o addopts= {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
 [testenv:code-style]
 description = Checks project code style
 skip_install = true
 deps = pre-commit
 commands =
-    pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
 [testenv:doc-{links,html}]
-description = Checks documentation links and pages generates properly
+description =
+    Checks
+    links: the integrity of all external links
+    html: if html documentation generates properly
 extras = doc
 setenv =
     links: BUILDER = linkcheck


### PR DESCRIPTION
Prepare the package for SCADE 2026 R1 that uses Python 3.12.

* Enable Python 3.12
* Update `tox.ini` for explicit tests using Python 3.7, 3.10 and 3.12