### PR TITLE
fix: Replace illegal filename characters

### DIFF
--- a/doc/changelog.d/23.fixed.md
+++ b/doc/changelog.d/23.fixed.md
@@ -1,0 +1,1 @@
+fix: Replace illegal filename characters

--- a/src/ansys/scade/pyalmgw/llrs.py
+++ b/src/ansys/scade/pyalmgw/llrs.py
@@ -39,7 +39,7 @@ from abc import ABCMeta, abstractmethod
 from argparse import ArgumentParser
 from base64 import b64encode
 from pathlib import Path
-from re import compile
+from re import compile, sub
 import subprocess
 import sys
 from typing import Any, List, Optional
@@ -811,7 +811,9 @@ class ScadeLLRS(AnnotatedLLRS):
             return None
         path = Path(self.llr_export.project.pathname).parent / 'llr_img'
         path.mkdir(exist_ok=True)
-        path = (path / (item.name + '.png')).as_posix()
+        # name may contain illegal characters (equation sets)
+        name = sub(r'[*"/\\<>:|?]', '_', item.name)
+        path = (path / (name + '.png')).as_posix()
         scade.print(item, path, 'png')
         return path
 
@@ -908,7 +910,9 @@ class SystemLLRS(AnnotatedLLRS):
         """Implement ``get_item_image``."""
         if not isinstance(item, scade.model.architect.Diagram):
             return None
-        path = Path(self.llr_export.project.pathname).parent / 'llr_img' / f'{item.name}.png'
+        # name may contain illegal characters?
+        name = sub(r'[*"/\\<>:|?]', '_', item.name)
+        path = Path(self.llr_export.project.pathname).parent / 'llr_img' / f'{name}.png'
         path.parent.mkdir(exist_ok=True)
         scade.print(item, str(path), 'png')
         return path.as_posix()

--- a/tests/ScadeLLRS/P.ann
+++ b/tests/ScadeLLRS/P.ann
@@ -6,7 +6,7 @@ BEGIN
         information {
             Nature ENUM
             {
-            	 NT_ENUM_VALUES {"Low Level Requirement", "Architecture", "Derived Low Level Requirement"},
+            	 NT_ENUM_VALUES {"Low Level Requirement", "Architecture", "Derived Low Level Requirement", ""},
             	 NT_DEFAULT_VALUE "Low Level Requirement" ,
             	 NT_FIELD_WIDTH 20 ,
             	 LLR_PROP "Nature" },
@@ -32,6 +32,7 @@ Notes-Values { Esterel-Technologies }  DEFINITIONS ::=
 BEGIN
     DesignElement ::= {
         {"!ed/6a/6294/AC5C/67336f72efd", "DesignElement","" , "" },
+        {"!ed/79/345F/D1BC/67ea40107305", "DesignElement_1","Low Level Requirement" , "" },
         {"!ed/35/6294/AC5C/67336ede4e9d", "DesignElement","Derived Low Level Requirement" , "" }}
     Remark ::= {
         {"!ed/14/6294/AC5C/67336eb642c", "Remark","Remark" }}

--- a/tests/ScadeLLRS/P.xscade
+++ b/tests/ScadeLLRS/P.xscade
@@ -464,6 +464,11 @@
 											<presentable>!ed/5f/6294/AC5C/67336f57766</presentable>
 											<presentable>!ed/65/6294/AC5C/67336f59638d</presentable>
 										</EquationSet>
+										<EquationSet name="Wrong *f&quot;i/l\e&lt;n&gt;a:m|e?" oid="!ed/79/345F/D1BC/67ea40107305">
+											<presentable>!ed/57/6294/AC5C/67336f3e6603</presentable>
+											<presentable>!ed/95/6294/AC5C/67336fef5b59</presentable>
+											<presentable>!ed/97/6294/AC5C/673370061a92</presentable>
+										</EquationSet>
 									</equationSets>
 								</NetDiagram>
 								<TextDiagram name="Textual" landscape="false" format="A4 (210 297)" oid="!ed/35/6294/AC5C/67336ede4e9d"/>

--- a/tests/ref/scade_llrs.json
+++ b/tests/ref/scade_llrs.json
@@ -381,6 +381,22 @@
                                                             "pathname": "P::O/Graphical/EQ/",
                                                             "scadetype": "equationSet",
                                                             "url": "http://localhost:8080/scade_provider/services/_vejBYKEJEe-4oO9EmPYzqg/requirements/IWVkLzZhLzYyOTQvQUM1Qy82NzMzNmY3MmVmZA=="
+                                                        },
+                                                        {
+                                                            "almtype": "req",
+                                                            "attributes": [
+                                                                {
+                                                                    "name": "Nature",
+                                                                    "value": "Low Level Requirement"
+                                                                }
+                                                            ],
+                                                            "icon": "$(SCADE)/SCADE LifeCycle/ALM Gateway/reqtifygw/icons/suite/equationSet.png",
+                                                            "image": "$(ROOT)/tests/ScadeLLRS/llr_img/Wrong _f_i_l_e_n_a_m_e_.png",
+                                                            "name": "Wrong *f\"i/l\\e<n>a:m|e?",
+                                                            "oid": "!ed/79/345F/D1BC/67ea40107305",
+                                                            "pathname": "P::O/Graphical/Wrong *f\"i/l\\e<n>a:m|e?/",
+                                                            "scadetype": "equationSet",
+                                                            "url": "http://localhost:8080/scade_provider/services/_vejBYKEJEe-4oO9EmPYzqg/requirements/IWVkLzc5LzM0NUYvRDFCQy82N2VhNDAxMDczMDU="
                                                         }
                                                     ],
                                                     "icon": "$(PYALMGW)/res/suite/netDiagram.png",


### PR DESCRIPTION
Some model elements can have names composed of any characters, leading to incorrect filenames when exporting the images.
This fix replaces illegal characters by `_` (underscore).