### PR TITLE
test: Fix typo for image directory

### DIFF
--- a/doc/changelog.d/27.test.md
+++ b/doc/changelog.d/27.test.md
@@ -1,0 +1,1 @@
+test: Fix typo for image directory

--- a/tests/test_llrs.py
+++ b/tests/test_llrs.py
@@ -241,7 +241,7 @@ def test_display(local_tmpdir, display: std.Project):
 
 def test_display_llrs(local_tmpdir, display_llrs: std.Project):
     """Test DisplayLLRS."""
-    img = _root_dir / 'tests' / 'ScadeLLRS' / 'llr_img'
+    img = _root_dir / 'tests' / 'DisplayLLRS' / 'llr_img'
     if img.exists():
         shutil.rmtree(img)
     schema = _root_dir / 'tests' / 'DisplayLLRS' / 'sample.json'


### PR DESCRIPTION
The `img` directory for SCADE Display unit tests is incorrect: copy/paste issue.