### PR TITLE
fix: Do not raise an exception for incorrect properties.

### DIFF
--- a/doc/changelog.d/60.fixed.md
+++ b/doc/changelog.d/60.fixed.md
@@ -1,0 +1,1 @@
+Do not raise an exception for incorrect properties.

--- a/doc/source/usage/schema.rst
+++ b/doc/source/usage/schema.rst
@@ -96,6 +96,8 @@ The properties of a class are described in the list ``properties``. Each propert
 Prefixes allow declaring references that can be bound in the ALM tool.
 For example, a DXL script can search for all properties starting by the prefix and create an internal link to ease the navigation.
 
+Note: when a property can't be evaluated, its value has the following form: ``<error: {path}>``, for example ``<error: type.name>``.
+
 **Example 1:**
 
 .. code-block:: json

--- a/src/ansys/scade/pyalmgw/llrs.py
+++ b/src/ansys/scade/pyalmgw/llrs.py
@@ -455,10 +455,12 @@ class LLRS(metaclass=ABCMeta):
             try:
                 items = self.get_item_links(dstitem, role, False)
             except BaseException:
-                raise PathError(
-                    path,
-                    "Invalid role '{0}' for class {1}".format(role, self.get_item_class(dstitem)),
-                )
+                # issue #59: return '<error>' instead of raising an exception
+                # raise PathError(
+                #     path,
+                #     "Invalid role '{0}' for class {1}".format(role, self.get_item_class(dstitem)),
+                # )
+                return f'<error: {path}>'
             if len(items) == 0:
                 # for example type.name and type is None
                 return ''
@@ -470,12 +472,14 @@ class LLRS(metaclass=ABCMeta):
         try:
             value = self.get_item_attribute(dstitem, path_elements[-1])
         except BaseException:
-            raise PathError(
-                path,
-                "Invalid attribute '{0}' for class {1}".format(
-                    path_elements[-1], self.get_item_class(dstitem)
-                ),
-            )
+            # issue #59: return '<error>' instead of raising an exception
+            # raise PathError(
+            #     path,
+            #     "Invalid attribute '{0}' for class {1}".format(
+            #         path_elements[-1], self.get_item_class(dstitem)
+            #     ),
+            # )
+            value = f'<error: {path}>'
         return value
 
     def get_links(self, item: Any, path: str, sort: bool) -> List[Any]:
@@ -627,6 +631,10 @@ class LLRS(metaclass=ABCMeta):
                 elif name[0] == '#':
                     # value is expected to be a reference
                     value = self.get_item_oid(value)
+                    if not value:
+                        # for example: anonymous types (use case derived from #59)
+                        # some ALM tools raise exceptions with empty values
+                        value = self.llr_export.empty
                 attributes.append({'name': name, 'value': str(value)})
 
             if len(attributes) != 0:

--- a/tests/Schemas/P.xscade
+++ b/tests/Schemas/P.xscade
@@ -562,6 +562,25 @@
 								</ed:Variable>
 							</pragmas>
 						</Variable>
+						<Variable name="a">
+							<type>
+								<Table>
+									<type>
+										<NamedType>
+											<type>
+												<TypeRef name="uint8"/>
+											</type>
+										</NamedType>
+									</type>
+									<size>
+										<ConstValue value="8"/>
+									</size>
+								</Table>
+							</type>
+							<pragmas>
+								<ed:Variable oid="!ed/8f/3870/90C4/6a15bb883075"/>
+							</pragmas>
+						</Variable>
 					</inputs>
 					<locals>
 						<Variable name="_L1">

--- a/tests/ref/schema_attribute_path.json
+++ b/tests/ref/schema_attribute_path.json
@@ -53,6 +53,23 @@
                     "oid": "!ed/3bf/6294/AC5C/6734d01b4111",
                     "pathname": "P::Attribute/u/",
                     "scadetype": "LocalVariable"
+                },
+                {
+                    "almtype": "req",
+                    "attributes": [
+                        {
+                            "name": "@Type",
+                            "value": "P::Attribute/a/"
+                        },
+                        {
+                            "name": "@Usage",
+                            "value": "<empty>"
+                        }
+                    ],
+                    "name": "a",
+                    "oid": "!ed/8f/3870/90C4/6a15bb883075",
+                    "pathname": "P::Attribute/a/",
+                    "scadetype": "LocalVariable"
                 }
             ],
             "name": "Schemas",

--- a/tests/ref/schema_attribute_value.json
+++ b/tests/ref/schema_attribute_value.json
@@ -53,6 +53,23 @@
                     "oid": "!ed/3bf/6294/AC5C/6734d01b4111",
                     "pathname": "P::Attribute/u/",
                     "scadetype": "LocalVariable"
+                },
+                {
+                    "almtype": "req",
+                    "attributes": [
+                        {
+                            "name": "Type",
+                            "value": "<error: type.name>"
+                        },
+                        {
+                            "name": "Comment",
+                            "value": "<empty>"
+                        }
+                    ],
+                    "name": "a",
+                    "oid": "!ed/8f/3870/90C4/6a15bb883075",
+                    "pathname": "P::Attribute/a/",
+                    "scadetype": "LocalVariable"
                 }
             ],
             "name": "Schemas",

--- a/tests/ref/schema_path_error_end.json
+++ b/tests/ref/schema_path_error_end.json
@@ -61,6 +61,6 @@
         }
     ],
     "name": "Schemas",
-    "path": "D:/AnsysDev/Nobackup/PyAnsys/pyalmgw/tests/Schemas/Schemas.etp",
+    "path": "$(ROOT)/tests/Schemas/Schemas.etp",
     "type": "suite"
 }

--- a/tests/ref/schema_path_error_end.json
+++ b/tests/ref/schema_path_error_end.json
@@ -7,8 +7,8 @@
                     "almtype": "req",
                     "attributes": [
                         {
-                            "name": "#Type",
-                            "value": "!ed/36a/6294/AC5C/6734ca9f457f"
+                            "name": "Type",
+                            "value": "<error: type.unknown>"
                         }
                     ],
                     "name": "b",
@@ -20,8 +20,8 @@
                     "almtype": "req",
                     "attributes": [
                         {
-                            "name": "#Type",
-                            "value": "!ed/373/6294/AC5C/6734caba49c"
+                            "name": "Type",
+                            "value": "<error: type.unknown>"
                         }
                     ],
                     "name": "f",
@@ -33,7 +33,7 @@
                     "almtype": "req",
                     "attributes": [
                         {
-                            "name": "#Type",
+                            "name": "Type",
                             "value": "<empty>"
                         }
                     ],
@@ -46,8 +46,8 @@
                     "almtype": "req",
                     "attributes": [
                         {
-                            "name": "#Type",
-                            "value": "<empty>"
+                            "name": "Type",
+                            "value": "<error: type.unknown>"
                         }
                     ],
                     "name": "a",
@@ -61,6 +61,6 @@
         }
     ],
     "name": "Schemas",
-    "path": "$(ROOT)/tests/Schemas/Schemas.etp",
+    "path": "D:/AnsysDev/Nobackup/PyAnsys/pyalmgw/tests/Schemas/Schemas.etp",
     "type": "suite"
 }

--- a/tests/ref/schema_path_error_start.json
+++ b/tests/ref/schema_path_error_start.json
@@ -61,6 +61,6 @@
         }
     ],
     "name": "Schemas",
-    "path": "D:/AnsysDev/Nobackup/PyAnsys/pyalmgw/tests/Schemas/Schemas.etp",
+    "path": "$(ROOT)/tests/Schemas/Schemas.etp",
     "type": "suite"
 }

--- a/tests/ref/schema_path_error_start.json
+++ b/tests/ref/schema_path_error_start.json
@@ -7,8 +7,8 @@
                     "almtype": "req",
                     "attributes": [
                         {
-                            "name": "#Type",
-                            "value": "!ed/36a/6294/AC5C/6734ca9f457f"
+                            "name": "Type",
+                            "value": "<error: unknown.name>"
                         }
                     ],
                     "name": "b",
@@ -20,8 +20,8 @@
                     "almtype": "req",
                     "attributes": [
                         {
-                            "name": "#Type",
-                            "value": "!ed/373/6294/AC5C/6734caba49c"
+                            "name": "Type",
+                            "value": "<error: unknown.name>"
                         }
                     ],
                     "name": "f",
@@ -33,8 +33,8 @@
                     "almtype": "req",
                     "attributes": [
                         {
-                            "name": "#Type",
-                            "value": "<empty>"
+                            "name": "Type",
+                            "value": "<error: unknown.name>"
                         }
                     ],
                     "name": "u",
@@ -46,8 +46,8 @@
                     "almtype": "req",
                     "attributes": [
                         {
-                            "name": "#Type",
-                            "value": "<empty>"
+                            "name": "Type",
+                            "value": "<error: unknown.name>"
                         }
                     ],
                     "name": "a",
@@ -61,6 +61,6 @@
         }
     ],
     "name": "Schemas",
-    "path": "$(ROOT)/tests/Schemas/Schemas.etp",
+    "path": "D:/AnsysDev/Nobackup/PyAnsys/pyalmgw/tests/Schemas/Schemas.etp",
     "type": "suite"
 }

--- a/tests/test_llrs.py
+++ b/tests/test_llrs.py
@@ -279,6 +279,8 @@ def test_system(local_tmpdir):
         'sibling.json',
         'sort.json',
         'unknown.json',
+        'path_error_end.json',
+        'path_error_start.json',
     ],
 )
 def test_schema_nominal(local_tmpdir, schemas: Tuple[std.Project, suite.Session], schema: str):
@@ -293,8 +295,6 @@ def test_schema_nominal(local_tmpdir, schemas: Tuple[std.Project, suite.Session]
 @pytest.mark.parametrize(
     'schema',
     [
-        'path_error_end.json',
-        'path_error_start.json',
         'path_error_syntax.json',
         'path_error_unknown.json',
     ],
@@ -314,7 +314,6 @@ def test_schema_robustness(local_tmpdir, schemas: Tuple[std.Project, suite.Sessi
     [
         [0, 'Unknown/Unknown.vsp', [_root_dir / 'tests' / 'Unknown' / 'noschema.json']],
         [1, 'Schemas/Schemas.etp', []],
-        [2, 'Schemas/Schemas.etp', [_root_dir / 'tests' / 'Schemas' / 'path_error_end.json']],
     ],
 )
 def test_llr_robustness(local_tmpdir, index, project, args):


### PR DESCRIPTION
When a property can't be evaluated, for example the name of an anonymous type, set a value indicating the error instead of raising an exception. For example: `<error: type.name>`.