### PR TITLE
fix: Provide a workaround for identifier/text mismatch when importing requirements documents

### DIFF
--- a/doc/changelog.d/61.fixed.md
+++ b/doc/changelog.d/61.fixed.md
@@ -1,0 +1,1 @@
+Provide a workaround for identifier/text mismatch when importing requirements documents

--- a/src/ansys/scade/pyalmgw/documents.py
+++ b/src/ansys/scade/pyalmgw/documents.py
@@ -128,7 +128,14 @@ class Element(ReqObject):
     def attributes(self) -> Dict[str, str]:
         """Return the attributes to be serialized as a dictionary."""
         attributes_ = super().attributes
-        attributes_.update({'identifier': self.identifier, 'text': self.text})
+        # SCADE Suite displays 'identifier' in the requirements tree
+        # and SCADE Display displays 'text'
+        # (tested with 2025 R2)
+        # -> for external connectors that provide only one of those data,
+        #    use it for both attributes
+        identifier = self.identifier if self.identifier else self.text
+        text = self.text if self.text else self.identifier
+        attributes_.update({'identifier': identifier, 'text': text})
         return attributes_
 
 


### PR DESCRIPTION
SCADE Suite displays `identifier` in the requirements tree and SCADE Display displays `text` (tested with 2025 R2).
As a workaround, for external connectors that provide only one of those data, use it for both attributes
